### PR TITLE
feat: add SNI support

### DIFF
--- a/Source/SSLClients.cpp
+++ b/Source/SSLClients.cpp
@@ -301,6 +301,9 @@ namespace DiscordCoreInternal {
 			reportSSLError("SSL_set_fd() Error: ", returnValue, this->ssl);
 			return;
 		}
+		
+		/* SNI */
+		SSL_set_tlsext_host_name(this->ssl, baseUrlNew.c_str());
 
 		returnValue = SSL_connect(this->ssl);
 		if (returnValue != 1) {


### PR DESCRIPTION
Allows connection to HTTP servers that have multiple SSL virtual hosts listening on the same IP address via use of [Server Name Identification](https://www.globalsign.com/en/blog/what-is-server-name-indication).

Adds the SLL macro call `SSL_set_tlsext_host_name()` that passes the server name in the client `HELLO` before the connection takes place.