### PR TITLE
Fixed ffmpeg header that was causing link issues on linux

### DIFF
--- a/Source/AudioDecoder.cpp
+++ b/Source/AudioDecoder.cpp
@@ -18,7 +18,10 @@
 /// \file AudioDecoder.cpp
 
 #include <discordcoreapi/AudioDecoder.hpp>
+
+extern "C" {
 #include <libavcodec/avcodec.h>
+}
 
 namespace DiscordCoreInternal {
 


### PR DESCRIPTION
https://github.com/RealTimeChris/DiscordCoreAPI/pull/21 introduced a issue when linking with the lib