### PR TITLE
fixed/changed function signatures

### DIFF
--- a/Documentation/Doxygen/Documentation-Examples/Login-Setup/Adding a Command.md
+++ b/Documentation/Doxygen/Documentation-Examples/Login-Setup/Adding a Command.md
@@ -67,7 +67,7 @@ namespace DiscordCoreAPI {
 
 #include <discordcoreapi/Index.hpp>
 
-Int32 main() {
+int main() {
 	String botToken = "YOUR_BOT_TOKEN_HERE";
 	auto thePtr = std::make_unique<DiscordCoreAPI::DiscordCoreClient>(botToken);
 	thePtr->registerFunction(Vector<String> {"test"}, std::make_unique<DiscordCoreAPI::Test>());

--- a/Documentation/Doxygen/Documentation-Examples/Login-Setup/Login-Instantiation.md
+++ b/Documentation/Doxygen/Documentation-Examples/Login-Setup/Login-Instantiation.md
@@ -17,7 +17,7 @@ Login/Instantiation {#logininstantiation}
 
 #include <Index.hpp>
 
-Int32 main()
+int main()
 {
 	String botToken {"YOUR_BOT_TOKEN_HERE"};
 	UniquePtr<DiscordCoreAPI::DiscordCoreClient> thePtr = std::make_unique<DiscordCoreAPI::DiscordCoreClient>(


### PR DESCRIPTION
changed two function signatures to use standard integers since Int32 isn't available on all supported systems